### PR TITLE
Add a no-style variation for prettier

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ For projects that use JSDoc for documenting code, it might come in handy to use 
   plugins: ['jsdoc']
 ```
 
+#### Using with Prettier
+If Prettier is used for style rules, then use the no-style variation of this plugin.
+Add `{ "extends": ["eslint-config-dhi/no-style"] }` to your `.eslintrc.js`.
 
 
 ### Running tests

--- a/no-style.js
+++ b/no-style.js
@@ -1,0 +1,35 @@
+module.exports = {
+  extends: [
+    './rules/best-practices',
+    './rules/errors',
+    './rules/node',
+    './rules/variables'
+  ].map(require.resolve),
+  env: {
+    browser: true,
+    node: true,
+    amd: false,
+    mocha: false,
+    jasmine: false
+  },
+  rules: {
+    'comma-dangle': ['error', 'never'],
+    'prefer-numeric-literals': 'off',
+    'no-restricted-properties': [
+      'error',
+      {
+        object: 'arguments',
+        property: 'callee',
+        message: 'arguments.callee is deprecated',
+      },
+      {
+        property: '__defineGetter__',
+        message: 'Please use Object.defineProperty instead.',
+      },
+      {
+        property: '__defineSetter__',
+        message: 'Please use Object.defineProperty instead.',
+      }
+    ]
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-dhi",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "DHI's base eslint configuration.",
   "repository": "DHI/eslint-config-dhi",
   "author": "DHI Group <info@dhigroup.com>",


### PR DESCRIPTION
Style lint rules don't mix well with https://github.com/prettier/prettier
This PR adds a way to import all rules except for 'style'.